### PR TITLE
Added support for DefaultAzureCredential

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ env:
   AZURE_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_CREDENTIAL }}
   AZURE_CLIENT_ID: ${{ secrets.IDP_CLIENT_ID }}
   AZURE_TENANT_ID: ${{ secrets.IDP_TENANT_ID }}
+  AZURE_REDIS_SCOPES: ${{ secrets.IDP_SCOPES }}
 jobs:
   tests:
     strategy:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2023, Redis, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -50,11 +50,44 @@ from redis_entraid.cred_provider import *
 
 ### Step 2 - Create the credential provider via the factory method
 
+Following factory methods are offered depends on authentication type you need:
+
+`create_from_managed_identity` - Creates a credential provider based on a managed identity. 
+Managed identities allow Azure services to authenticate without needing explicit credentials, as they are automatically assigned by Azure.
+
+`create_from_service_principal` - Creates a credential provider using a service principal. 
+A service principal is typically used when you want to authenticate as an application, rather than as a user, with Azure Active Directory.
+
+`create_from_default_azure_credential` - Creates a credential provider from a Default Azure Credential. 
+This method allows automatic selection of the appropriate credential mechanism based on the environment 
+(e.g., environment variables, managed identities, service principal, interactive browser etc.).
+
+#### Examples ####
+
+**Managed Identity**
+
+```python
+credential_provider = create_from_managed_identity(
+    identity_type=ManagedIdentityType.SYSTEM_ASSIGNED,
+    resource="https://redis.azure.com/"
+)
+```
+
+**Service principal**
+
 ```python
 credential_provider = create_from_service_principal(
     CLIENT_ID, 
     CLIENT_SECRET, 
     TENANT_ID
+)
+```
+
+**Default Azure Credential**
+
+```python
+credential_provider = create_from_default_azure_credential(
+    ("https://redis.azure.com/.default",),
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ credential_provider = create_from_default_azure_credential(
 )
 ```
 
+More examples available in [examples](https://github.com/redis/redis-py-entraid/tree/vv-default-azure-credentials/examples)
+folder.
+
 ### Step 3 - Provide optional token renewal configuration
 
 The default configuration would be applied, but you're able to customise it.

--- a/examples/interactive_browser_login.py
+++ b/examples/interactive_browser_login.py
@@ -1,0 +1,28 @@
+# Before run this example you need to configure your EntraID application the following way:
+#
+# 1. Enable "Allow public client flows" option, under "Authentication" section.
+# 2. Add the Redirect URL of the web server that DefaultAzureCredential runs
+# By default, uses port 8400, so the default Redirect URL looks like "http://localhost:8400".
+
+import os
+
+from redis_entraid.cred_provider import create_from_default_azure_credential
+
+def main():
+
+    # By default, interactive browser login is excluded so you need to enable it.
+    credential_provider = create_from_default_azure_credential(
+        ("user.read",),
+        app_kwargs={
+            "exclude_interactive_browser_credential": False,
+            "interactive_browser_client_id": os.getenv("AZURE_CLIENT_ID"),
+            "interactive_browser_tenant_id": os.getenv("AZURE_TENANT_ID"),
+        }
+    )
+
+    # Opens a browser tab. After you'll enter your username/password it would return you a credentials needed for auth.
+    print(credential_provider.get_credentials())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/interactive_browser_login.py
+++ b/examples/interactive_browser_login.py
@@ -6,13 +6,14 @@
 
 import os
 
+from redis import Redis
 from redis_entraid.cred_provider import create_from_default_azure_credential
 
 def main():
 
     # By default, interactive browser login is excluded so you need to enable it.
     credential_provider = create_from_default_azure_credential(
-        ("user.read",),
+        scopes=("user.read",),
         app_kwargs={
             "exclude_interactive_browser_credential": False,
             "interactive_browser_client_id": os.getenv("AZURE_CLIENT_ID"),
@@ -20,8 +21,10 @@ def main():
         }
     )
 
-    # Opens a browser tab. After you'll enter your username/password it would return you a credentials needed for auth.
-    print(credential_provider.get_credentials())
+    # Opens a browser tab. After you'll enter your username/password you'll be authenticated.
+    # When using Entra ID, Azure enforces TLS on your Redis connection.
+    client = Redis(host=HOST, port=PORT, ssl=True, ssl_cert_reqs=None, credential_provider=credential_provider)
+    print("The database size is: {}".format(client.dbsize()))
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "redis~=5.3.0b3",
   "PyJWT~=2.9.0",
   "msal~=1.31.0",
+  "azure-identity~=1.20.0"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 include = ["redis_entraid"]
-exclude = ["tests", ".github"]
+exclude = ["tests", "examples", ".github"]

--- a/redis_entraid/cred_provider.py
+++ b/redis_entraid/cred_provider.py
@@ -164,7 +164,7 @@ def create_from_service_principal(
 
 def create_from_default_azure_credential(
         scopes: Tuple[str],
-        additional_tenant_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
         authority: Optional[str] = None,
         token_kwargs: Optional[dict] = {},
         app_kwargs: Optional[dict] = {},
@@ -183,7 +183,7 @@ def create_from_default_azure_credential(
     https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python
 
     :param scopes: Service principal scopes. Fallback to default scopes if None.
-    :param additional_tenant_id: Optional tenant to include in the token request.
+    :param tenant_id: Optional tenant to include in the token request.
     :param authority: Custom authority, by default used  'login.microsoftonline.com'
     :param token_kwargs: Optional token arguments applied when retrieving tokens.
     :param app_kwargs: Optional keyword arguments to pass when instantiating application.
@@ -192,7 +192,7 @@ def create_from_default_azure_credential(
     default_azure_credential_config = DefaultAzureCredentialIdentityProviderConfig(
         scopes=scopes,
         authority=authority,
-        additional_tenant_id=additional_tenant_id,
+        additional_tenant_id=tenant_id,
         token_kwargs=token_kwargs,
         app_kwargs=app_kwargs,
     )

--- a/redis_entraid/cred_provider.py
+++ b/redis_entraid/cred_provider.py
@@ -163,7 +163,7 @@ def create_from_service_principal(
 
 
 def create_from_default_azure_credential(
-        scopes: Optional[tuple[str]] = None,
+        scopes: Optional[Tuple[str]] = None,
         tenant_id: Optional[str] = None,
         authority: Optional[str] = None,
         token_kwargs: Optional[dict] = {},

--- a/redis_entraid/cred_provider.py
+++ b/redis_entraid/cred_provider.py
@@ -163,8 +163,8 @@ def create_from_service_principal(
 
 
 def create_from_default_azure_credential(
-        scopes: Optional[Tuple[str]] = None,
-        tenant_id: Optional[str] = None,
+        scopes: Tuple[str],
+        additional_tenant_id: Optional[str] = None,
         authority: Optional[str] = None,
         token_kwargs: Optional[dict] = {},
         app_kwargs: Optional[dict] = {},
@@ -183,7 +183,7 @@ def create_from_default_azure_credential(
     https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python
 
     :param scopes: Service principal scopes. Fallback to default scopes if None.
-    :param tenant_id: Optional tenant to include in the token request.
+    :param additional_tenant_id: Optional tenant to include in the token request.
     :param authority: Custom authority, by default used  'login.microsoftonline.com'
     :param token_kwargs: Optional token arguments applied when retrieving tokens.
     :param app_kwargs: Optional keyword arguments to pass when instantiating application.
@@ -192,7 +192,7 @@ def create_from_default_azure_credential(
     default_azure_credential_config = DefaultAzureCredentialIdentityProviderConfig(
         scopes=scopes,
         authority=authority,
-        tenant_id=tenant_id,
+        additional_tenant_id=additional_tenant_id,
         token_kwargs=token_kwargs,
         app_kwargs=app_kwargs,
     )

--- a/redis_entraid/cred_provider.py
+++ b/redis_entraid/cred_provider.py
@@ -6,7 +6,8 @@ from redis.auth.token_manager import TokenManagerConfig, RetryPolicy, TokenManag
 
 from redis_entraid.identity_provider import ManagedIdentityType, ManagedIdentityIdType, \
     _create_provider_from_managed_identity, ManagedIdentityProviderConfig, ServicePrincipalIdentityProviderConfig, \
-    _create_provider_from_service_principal
+    _create_provider_from_service_principal, DefaultAzureCredentialIdentityProviderConfig, \
+    _create_provider_from_default_azure_credential
 
 DEFAULT_EXPIRATION_REFRESH_RATIO = 0.7
 DEFAULT_LOWER_REFRESH_BOUND_MILLIS = 0
@@ -158,4 +159,42 @@ def create_from_service_principal(
         token_kwargs=token_kwargs,
     )
     idp = _create_provider_from_service_principal(service_principal_config)
+    return EntraIdCredentialsProvider(idp, token_manager_config)
+
+
+def create_from_default_azure_credential(
+        scopes: Optional[tuple[str]] = None,
+        tenant_id: Optional[str] = None,
+        authority: Optional[str] = None,
+        token_kwargs: Optional[dict] = {},
+        app_kwargs: Optional[dict] = {},
+        token_manager_config: Optional[TokenManagerConfig] = TokenManagerConfig(
+            DEFAULT_EXPIRATION_REFRESH_RATIO,
+            DEFAULT_LOWER_REFRESH_BOUND_MILLIS,
+            DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_IN_MS,
+            RetryPolicy(
+                DEFAULT_MAX_ATTEMPTS,
+                DEFAULT_DELAY_IN_MS
+            )
+        )
+) -> EntraIdCredentialsProvider:
+    """
+    Create a credential provider from a Default Azure credential.
+    https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python
+
+    :param scopes: Service principal scopes. Fallback to default scopes if None.
+    :param tenant_id: Optional tenant to include in the token request.
+    :param authority: Custom authority, by default used  'login.microsoftonline.com'
+    :param token_kwargs: Optional token arguments applied when retrieving tokens.
+    :param app_kwargs: Optional keyword arguments to pass when instantiating application.
+    :param token_manager_config: Token manager specific configuration.
+    """
+    default_azure_credential_config = DefaultAzureCredentialIdentityProviderConfig(
+        scopes=scopes,
+        authority=authority,
+        tenant_id=tenant_id,
+        token_kwargs=token_kwargs,
+        app_kwargs=app_kwargs,
+    )
+    idp = _create_provider_from_default_azure_credential(default_azure_credential_config)
     return EntraIdCredentialsProvider(idp, token_manager_config)

--- a/redis_entraid/identity_provider.py
+++ b/redis_entraid/identity_provider.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Any, List, Tuple
+from typing import Optional, Any, List, Tuple, Iterable
 
 import requests
 from azure.identity import DefaultAzureCredential
@@ -48,7 +48,7 @@ class ServicePrincipalIdentityProviderConfig:
 
 @dataclass
 class DefaultAzureCredentialIdentityProviderConfig:
-    scopes: Tuple[str]
+    scopes: Iterable[str]
     additional_tenant_id: Optional[str] = None
     authority: Optional[str] = None
     token_kwargs: Optional[dict] = field(default_factory=dict)

--- a/redis_entraid/identity_provider.py
+++ b/redis_entraid/identity_provider.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Any, List
+from typing import Optional, Any, List, Tuple
 
 import requests
 from azure.identity import DefaultAzureCredential
@@ -48,7 +48,7 @@ class ServicePrincipalIdentityProviderConfig:
 
 @dataclass
 class DefaultAzureCredentialIdentityProviderConfig:
-    scopes: Optional[tuple[str]] = None
+    scopes: Optional[Tuple[str]] = None
     tenant_id: Optional[str] = None
     authority: Optional[str] = None
     token_kwargs: Optional[dict] = field(default_factory=dict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyJWT~=2.9.0
 msal~=1.31.0
+azure-identity~=1.20.0
 redis==5.3.0b4
 requests~=2.32.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Union
 
 import pytest
-from msal.managed_identity import ManagedIdentity
 from redis import CredentialProvider
 from redis.auth.token_manager import TokenManagerConfig, RetryPolicy
 
@@ -160,7 +159,7 @@ def get_credential_provider(request) -> CredentialProvider:
     if isinstance(idp_config, DefaultAzureCredentialIdentityProviderConfig):
         return create_from_default_azure_credential(
             idp_config.scopes,
-            idp_config.tenant_id,
+            idp_config.additional_tenant_id,
             idp_config.authority,
             idp_config.token_kwargs,
             idp_config.app_kwargs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def _get_service_principal_provider_config(request) -> ServicePrincipalIdentityP
 
 
 def _get_default_azure_credential_provider_config(request) -> DefaultAzureCredentialIdentityProviderConfig:
-    scopes = os.getenv("AZURE_REDIS_SCOPES", None)
+    scopes = os.getenv("AZURE_REDIS_SCOPES", ())
 
     if hasattr(request, "param"):
         kwargs = request.param.get("idp_kwargs", {})

--- a/tests/test_cred_provider.py
+++ b/tests/test_cred_provider.py
@@ -46,6 +46,35 @@ class TestEntraIdCredentialsProvider:
         credentials = credential_provider.get_credentials()
         assert len(credentials) == 2
 
+    @pytest.mark.parametrize(
+        "credential_provider",
+        [
+            {
+                "idp_kwargs": {"auth_type": AuthType.DEFAULT_AZURE_CREDENTIAL},
+            },
+        ],
+        ids=["Default Azure Credentials (via EnvironmentCredential)"],
+        indirect=True,
+    )
+    def test_get_credentials_default_azure_credential_env(self, credential_provider: EntraIdCredentialsProvider):
+        credentials = credential_provider.get_credentials()
+        assert len(credentials) == 2
+
+    @pytest.mark.parametrize(
+        "credential_provider",
+        [
+            {
+                "idp_kwargs": {"auth_type": AuthType.DEFAULT_AZURE_CREDENTIAL},
+            },
+        ],
+        ids=["Default Azure Credentials (via ManagedIdentityCredential)"],
+        indirect=True,
+    )
+    @pytest.mark.managed_identity
+    def test_get_credentials_default_azure_credential_managed(self, credential_provider: EntraIdCredentialsProvider):
+        credentials = credential_provider.get_credentials()
+        assert len(credentials) == 2
+
 
     @pytest.mark.parametrize(
         "credential_provider",

--- a/tests/test_cred_provider.py
+++ b/tests/test_cred_provider.py
@@ -170,7 +170,7 @@ class TestEntraIdCredentialsProvider:
         "credential_provider",
         [
             {
-                "cred_provider_kwargs": {"expiration_refresh_ratio": 0.00001},
+                "cred_provider_kwargs": {"expiration_refresh_ratio": 0.00003},
             }
         ],
         indirect=True,

--- a/tests/test_cred_provider.py
+++ b/tests/test_cred_provider.py
@@ -170,7 +170,7 @@ class TestEntraIdCredentialsProvider:
         "credential_provider",
         [
             {
-                "cred_provider_kwargs": {"expiration_refresh_ratio": 0.00002},
+                "cred_provider_kwargs": {"expiration_refresh_ratio": 0.00001},
             }
         ],
         indirect=True,

--- a/tests/test_identity_provider.py
+++ b/tests/test_identity_provider.py
@@ -1,13 +1,26 @@
 import pytest
 from msal import TokenCache
 
-from redis_entraid.identity_provider import EntraIDIdentityProvider
+from redis_entraid.identity_provider import ServicePrincipalProvider, DefaultAzureCredentialProvider
+from tests.conftest import AuthType
 
 
 class TestEntraIDIdentityProvider:
     CUSTOM_CACHE = TokenCache()
 
-    def test_request_token_from_service_principal_identity(self, identity_provider: EntraIDIdentityProvider):
+    def test_request_token_from_service_principal_identity(self, identity_provider: ServicePrincipalProvider):
+        assert identity_provider.request_token(force_refresh=True)
+
+    @pytest.mark.parametrize(
+        "identity_provider",
+        [
+            {
+                "idp_kwargs": {"auth_type": AuthType.DEFAULT_AZURE_CREDENTIAL},
+            }
+        ],
+        indirect=True,
+    )
+    def test_request_token_from_default_azure_credential(self, identity_provider: DefaultAzureCredentialProvider):
         assert identity_provider.request_token(force_refresh=True)
 
     @pytest.mark.parametrize(
@@ -19,7 +32,7 @@ class TestEntraIDIdentityProvider:
         ],
         indirect=True,
     )
-    def test_request_token_caches_token_after_initial_request(self, identity_provider: EntraIDIdentityProvider):
+    def test_request_token_caches_token_after_initial_request(self, identity_provider: ServicePrincipalProvider):
         assert len(list(self.CUSTOM_CACHE.search(TokenCache.CredentialType.ACCESS_TOKEN))) == 0
 
         token = identity_provider.request_token()


### PR DESCRIPTION
1. Added new authentication type via DefaultAzureCredential. More information [here](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python).
2. Added `examples` folder with ready-to-use extended code examples.
3. Added LICENSE file
4. Refactor IdentityProvider, by separating into multiple providers